### PR TITLE
Fix filename case mismatch on case sensitive filesystems

### DIFF
--- a/src/ICM45686.h
+++ b/src/ICM45686.h
@@ -25,7 +25,7 @@
 extern "C" {
 #include "imu/inv_imu_driver_advanced.h"
 #include "imu/inv_imu_edmp.h"
-#include "invn/InvError.h"
+#include "Invn/InvError.h"
 #if defined(ICM45686S) || defined(ICM45605S)
 #include "imu/inv_imu_edmp_gaf.h"
 #endif


### PR DESCRIPTION
When compiling the library on a OS with case sensitive filesystem (for example, linux and xfs) the following error will occur:

```
In file included from /tmp/.arduinoIDE-unsaved20251013-3008126-1aaun72.clxrj/Polling_I2C/Polling_I2C.ino:18:
/home//Arduino/libraries/ICM45686/src/ICM45686.h:28:10: fatal error: invn/InvError.h: No such file or directory
   28 | #include "invn/InvError.h"
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
exit status 1
```

due to a case mismatch between the inclusion path in ICM45686.h (invn/InvError.h) and the actual path (Invn/InvError.h).

This patch corrects the inclusion path in ICM45686.h, which resolves the compilation error on case sensitive platforms.

This patch has been tested on Archlinux and Arduino IDE 2.3.6