### PR TITLE
Fix compile warning - implicit declaration of micros() in invn_mag.c

### DIFF
--- a/src/invn_mag.c
+++ b/src/invn_mag.c
@@ -24,6 +24,9 @@
 /* Magnetometer drivers */
 #include "Ict1531x/Ict1531x.h"
 
+/* Platform hook: forward declaration of Arduino's microsecond timer */
+extern unsigned long micros(void);
+
 /*
  * Static functions definition
  */


### PR DESCRIPTION
**Description**
`invn_mag.c` calls `micros()` (an Arduino platform function) without any declaration visible to the C compiler, resulting in:

```
invn_mag.c: warning: implicit declaration of function 'micros' [-Wimplicit-function-declaration]
```

This adds an `extern` forward declaration to make the implicit declaration explicit and removes the warning.
The declaration matches Arduino's actual signature (`unsigned long`).

**Verification**
Build with GCC using `-Wimplicit-function-declaration` - the warning should be gone.
