### PR TITLE
Fix WOM threshold macro redefinition and unsafe operator precedence

### DIFF
--- a/src/ICM45686.cpp
+++ b/src/ICM45686.cpp
@@ -78,7 +78,8 @@ float mag_data[3];
  * WOM threshold value in mg.
  * 1g/256 resolution (wom_th = mg * 256 / 1000)
  */
-#define DEFAULT_WOM_THS_MG 52 >> 2 // 52 mg
+#define DEFAULT_WOM_THS_MG     (52 >> 2) // 52 mg
+#define DEFAULT_WOM_AID_THS_MG (24 >> 2) // 24 mg
 
 #define Q11_DIV (1<<11)
 #define Q14_DIV (1<<14)
@@ -1080,9 +1081,6 @@ int ICM456xx::setApexInterrupt(uint8_t intpin, ICM456xx_irq_handler handler)
 
   return rc;
 }
-
-#define DEFAULT_WOM_THS_MG     52 >> 2 // 52 mg
-#define DEFAULT_WOM_AID_THS_MG 24 >> 2 // 24 mg
 
 int ICM456xx::startAPEX(dmp_ext_sen_odr_cfg_apex_odr_t edmp_odr, accel_config0_accel_odr_t accel_odr)
 {


### PR DESCRIPTION
**Description**
Two bugs in the WOM threshold macros:

1. **Unsafe operator precedence** - `#define DEFAULT_WOM_THS_MG 52 >> 2` expands without parentheses, so any expression using this macro (e.g. `x * DEFAULT_WOM_THS_MG`) evaluates as `x * 52 >> 2` instead of `x * (52 >> 2)`, giving a wrong result.  Wrapping macros in parentheses fixes the issue.

2. **Macro redefinition** - `DEFAULT_WOM_THS_MG` and `DEFAULT_WOM_AID_THS_MG` were defined a second time near `startAPEX()` (line ~1084), causing a redefinition warning and the earlier definition (used in `startWakeOnMotion`) to be overridden.  Removing the duplication fixes the issue.

**Verification**
Build and verify no redefinition warning.
Verify WOM threshold value passed to `inv_imu_adv_configure_wom` remains `13` (52 >> 2).
