### PR TITLE
Remove redundant inv_imu_edmp_gaf.h include from ICM45686.cpp

### DIFF
--- a/src/ICM45686.cpp
+++ b/src/ICM45686.cpp
@@ -17,9 +17,7 @@
  
 #include "Arduino.h"
 #include "ICM45686.h"
-#if (INV_DEVICE_TYPE == INV_TYPE_A2)
-#include "imu/inv_imu_edmp_gaf.h"
-#else
+#if (INV_DEVICE_TYPE != INV_TYPE_A2)
 #include "invn_mag.h"
 #include "Ict1531x/Ict1531x.h"
 /* 


### PR DESCRIPTION
**Description**

The `#if` guard at the top of `ICM45686.cpp` had this structure:

```cpp
#if (INV_DEVICE_TYPE == INV_TYPE_A2)
#include "imu/inv_imu_edmp_gaf.h"    // only for A2
#else
#include "invn_mag.h"                // for everything else
...
#endif
```

However `imu/inv_imu_edmp_gaf.h` is already included in the preceeding header file ICM45686.h (lines 47-49):
```cpp
#if (INV_DEVICE_TYPE == INV_TYPE_A2)
  #include "imu/inv_imu_edmp_gaf.h"
#endif
```

The standalone include in the `.cpp` is redundant and causes a potential double-include issue on A2 builds.

The fix simplifies the guard to `#if (INV_DEVICE_TYPE != INV_TYPE_A2)` and removes the redundant include.

**Verification**
Build with `-DICM45686` setting INV_DEVICE_TYPE to INV_TYPE_A1 and again with INV_TYPE_A2 - both should compile cleanly now.
