### PR TITLE
Add #error for undefined device type in ICM45686.h

### DIFF
--- a/src/ICM45686.h
+++ b/src/ICM45686.h
@@ -42,6 +42,8 @@ extern "C" {
   #define INV_DEVICE_TYPE INV_TYPE_B1
 #elif defined(ICM45689) || defined(ICM45608)
   #define INV_DEVICE_TYPE INV_TYPE_C1
+#else
+  #error "No ICM device macro defined. Add a build flag for your device (e.g. -DICM45686)."
 #endif
 
 #if (INV_DEVICE_TYPE == INV_TYPE_A2)


### PR DESCRIPTION
**Description**
If none of the device macros (`ICM45686`, `ICM45605`, `ICM45605S`, `ICM45686S`, `ICM45688P`, `ICM45689`, `ICM45608`) are defined at build time, `INV_DEVICE_TYPE` is left undefined.

All subsequent `#if (INV_DEVICE_TYPE == INV_TYPE_X)` guards silently evaluate to false, producing a binary that does nothing and gives no indication of the misconfiguration.

This adds a `#else #error` at the end of the device-type detection block so the user gets a clear compile-time message.

**Verification**
Build with no device macro defined - it should now produce a compile error with the message.
Build with `-DICM45686` or any other compatible values - it should compile cleanly.
