### PR TITLE
Use platform Wire buffer size instead of hardcoded 32

### DIFF
--- a/src/ICM45686.cpp
+++ b/src/ICM45686.cpp
@@ -56,7 +56,14 @@ static TwoWire *i2c = NULL;
 #define I2C_DEFAULT_CLOCK 400000
 #define I2C_MAX_CLOCK 1000000
 #define ICM456xx_I2C_ADDRESS 0x68
-#define ARDUINO_I2C_BUFFER_LENGTH 32
+// Use the platform-provided Wire buffer size where available, falling back to 32 (AVR default)
+#if defined(I2C_BUFFER_LENGTH)
+  #define ARDUINO_I2C_BUFFER_LENGTH I2C_BUFFER_LENGTH   // ESP32, RP2040, etc.
+#elif defined(BUFFER_LENGTH)
+  #define ARDUINO_I2C_BUFFER_LENGTH BUFFER_LENGTH        // AVR Arduino
+#else
+  #define ARDUINO_I2C_BUFFER_LENGTH 32                   // safe fallback
+#endif
 // spi
 static SPIClass *spi = NULL;
 static uint8_t chip_select_id = 0;


### PR DESCRIPTION
**Description**
This library currently defines `ARDUINO_I2C_BUFFER_LENGTH` as a hardcoded value of 32. This is the default buffer size on AVR-based Arduinos, but other platforms support larger buffers - ESP32 uses 128 bytes and RP2040 uses 256 bytes. 

Using the hardcoded value on these platforms causes unnecessary I2C read fragmentation, splitting transfers that could be completed in a single transaction which improves performance.

This replaces the hardcoded constant with a detection chain that uses the platform's own macro(if available):

**Scenarios**
`I2C_BUFFER_LENGTH` - defined by ESP32 and RP2040 Arduino cores
`BUFFER_LENGTH` - defined by AVR Arduino cores
falls back to 32 if neither is defined

**Verification**
Build with `-DBUFFER_LENGTH=32` (AVR) - `ARDUINO_I2C_BUFFER_LENGTH` resolves to 32, no behaviour change.
Build with `-DI2C_BUFFER_LENGTH=128` (ESP32) - `ARDUINO_I2C_BUFFER_LENGTH` resolves to 128, allowing full-buffer reads in a single I2C transaction.
Build with neither defined - falls back to 32, same as before (non-breaking change).