### PR TITLE
Fix NULL comparison for enum types in startAPEX

### DIFF
--- a/src/ICM45686.cpp
+++ b/src/ICM45686.cpp
@@ -1185,7 +1185,7 @@ int ICM456xx::startAPEX(dmp_ext_sen_odr_cfg_apex_odr_t edmp_odr, accel_config0_a
 {
   int rc = 0;
 
-  if(edmp_odr == NULL && accel_odr == NULL)
+  if(edmp_odr == 0 && accel_odr == 0)
   {
     if(apex_enable[ICM456XX_APEX_FF] || apex_enable[ICM456XX_APEX_LOWG] || apex_enable[ICM456XX_APEX_HIGHG])
     {


### PR DESCRIPTION
**Description**
`startAPEX()` compared two enum-typed parameters (`edmp_odr` and `accel_odr`) against `NULL`. Comparing an enum to `NULL` is invalid in C++ - `NULL` is a null pointer constant, not a valid sentinel for an integer-based enum. Some compilers warn or error on this; others silently coerce, making the zero-check unreliable and semantically misleading.

This replaces both `== NULL` comparisons with `== 0`, which is the correct way to test whether an enum parameter holds its zero value.

**Verification**
- Build with a C++ compiler that has `-Wzero-as-null-pointer-constant` or strict enum warnings enabled - the warning should no longer fire.
- Call `startAPEX(0, 0)` - should take the same code path as before.
- Call `startAPEX` with non-zero ODR values - behaviour unchanged (non-breaking change).