### PR TITLE
Add optional custom pin overloads for I2C and SPI constructors

### DIFF
--- a/src/ICM45686.cpp
+++ b/src/ICM45686.cpp
@@ -113,6 +113,8 @@ ICM456xx::ICM456xx(TwoWire &i2c_ref,bool lsb, uint32_t freq) {
   } else {
     clk_freq = I2C_DEFAULT_CLOCK;
   }
+  i2c_sda_pin = -1;
+  i2c_scl_pin = -1;
 }
 
 // ICM456xx constructor for I2c interface, default frequency
@@ -120,6 +122,31 @@ ICM456xx::ICM456xx(TwoWire &i2c_ref,bool lsb) {
   i2c = &i2c_ref; 
   i2c_address = ICM456xx_I2C_ADDRESS | (lsb ? 0x1 : 0);
   clk_freq = I2C_DEFAULT_CLOCK;
+  i2c_sda_pin = -1;
+  i2c_scl_pin = -1;
+}
+
+// ICM456xx constructor for I2c interface with custom pins
+ICM456xx::ICM456xx(TwoWire &i2c_ref, bool lsb, int sda, int scl) {
+  i2c = &i2c_ref;
+  i2c_address = ICM456xx_I2C_ADDRESS | (lsb ? 0x1 : 0);
+  clk_freq = I2C_DEFAULT_CLOCK;
+  i2c_sda_pin = sda;
+  i2c_scl_pin = scl;
+}
+
+// ICM456xx constructor for I2c interface with custom frequency and pins
+ICM456xx::ICM456xx(TwoWire &i2c_ref, bool lsb, uint32_t freq, int sda, int scl) {
+  i2c = &i2c_ref;
+  i2c_address = ICM456xx_I2C_ADDRESS | (lsb ? 0x1 : 0);
+  if ((freq <= I2C_MAX_CLOCK) && (freq >= 100000))
+  {
+    clk_freq = freq;
+  } else {
+    clk_freq = I2C_DEFAULT_CLOCK;
+  }
+  i2c_sda_pin = sda;
+  i2c_scl_pin = scl;
 }
 
 // ICM456xx constructor for spi interface
@@ -132,6 +159,9 @@ ICM456xx::ICM456xx(SPIClass &spi_ref,uint8_t cs_id, uint32_t freq) {
   } else {
     clk_freq = SPI_DEFAULT_CLOCK;
   }
+  spi_sck_pin  = -1;
+  spi_miso_pin = -1;
+  spi_mosi_pin = -1;
 }
 
 // ICM456xx constructor for spi interface, default frequency
@@ -139,6 +169,34 @@ ICM456xx::ICM456xx(SPIClass &spi_ref,uint8_t cs_id) {
   spi = &spi_ref;
   chip_select_id = cs_id; 
   clk_freq = SPI_DEFAULT_CLOCK;
+  spi_sck_pin  = -1;
+  spi_miso_pin = -1;
+  spi_mosi_pin = -1;
+}
+
+// ICM456xx constructor for spi interface with custom pins
+ICM456xx::ICM456xx(SPIClass &spi_ref, uint8_t cs_id, int sck, int miso, int mosi) {
+  spi = &spi_ref;
+  chip_select_id = cs_id;
+  clk_freq = SPI_DEFAULT_CLOCK;
+  spi_sck_pin  = sck;
+  spi_miso_pin = miso;
+  spi_mosi_pin = mosi;
+}
+
+// ICM456xx constructor for spi interface with custom frequency and pins
+ICM456xx::ICM456xx(SPIClass &spi_ref, uint8_t cs_id, uint32_t freq, int sck, int miso, int mosi) {
+  spi = &spi_ref;
+  chip_select_id = cs_id;
+  if ((freq <= SPI_MAX_CLOCK) && (freq >= 100000))
+  {
+    clk_freq = freq;
+  } else {
+    clk_freq = SPI_DEFAULT_CLOCK;
+  }
+  spi_sck_pin  = sck;
+  spi_miso_pin = miso;
+  spi_mosi_pin = mosi;
 }
 
 /* starts communication with the ICM456xx */
@@ -147,13 +205,19 @@ int ICM456xx::begin() {
   uint8_t who_am_i;
 
   if (i2c != NULL) {
-    i2c->begin();
+    if (i2c_sda_pin >= 0 && i2c_scl_pin >= 0)
+      i2c->begin(i2c_sda_pin, i2c_scl_pin);
+    else
+      i2c->begin();
     i2c->setClock(clk_freq);
     icm_driver.transport.serif_type = UI_I2C;
     icm_driver.transport.read_reg  = i2c_read;
     icm_driver.transport.write_reg = i2c_write;
   } else {
-    spi->begin();
+    if (spi_sck_pin >= 0 && spi_miso_pin >= 0 && spi_mosi_pin >= 0)
+      spi->begin(spi_sck_pin, spi_miso_pin, spi_mosi_pin, chip_select_id);
+    else
+      spi->begin();
     pinMode(chip_select_id,OUTPUT);
     digitalWrite(chip_select_id,HIGH);
     icm_driver.transport.serif_type = UI_SPI4;

--- a/src/ICM45686.h
+++ b/src/ICM45686.h
@@ -87,8 +87,12 @@ class ICM456xx {
   public:
     ICM456xx(TwoWire &i2c,bool address_lsb, uint32_t freq);
     ICM456xx(TwoWire &i2c,bool address_lsb);
+    ICM456xx(TwoWire &i2c,bool address_lsb, int sda, int scl);
+    ICM456xx(TwoWire &i2c,bool address_lsb, uint32_t freq, int sda, int scl);
     ICM456xx(SPIClass &spi,uint8_t chip_select_id, uint32_t freq);
     ICM456xx(SPIClass &spi,uint8_t chip_select_id);
+    ICM456xx(SPIClass &spi,uint8_t chip_select_id, int sck, int miso, int mosi);
+    ICM456xx(SPIClass &spi,uint8_t chip_select_id, uint32_t freq, int sck, int miso, int mosi);
     int begin();
     int startAccel(uint16_t odr, uint16_t fsr);
     int startGyro(uint16_t odr, uint16_t fsr);
@@ -178,6 +182,11 @@ class ICM456xx {
     accel_config0_accel_ui_fs_sel_t accel_fsr_g_to_param(uint16_t accel_fsr_g);
     gyro_config0_gyro_ui_fs_sel_t gyro_fsr_dps_to_param(uint16_t gyro_fsr_dps);
     int setup_irq(uint8_t intpin, ICM456xx_irq_handler handler);
+    int i2c_sda_pin;
+    int i2c_scl_pin;
+    int spi_sck_pin;
+    int spi_miso_pin;
+    int spi_mosi_pin;
     uint32_t step_cnt_ovflw;
     bool apex_enable[ICM456XX_APEX_MAX];
     dmp_ext_sen_odr_cfg_apex_odr_t apex_edmp_odr;


### PR DESCRIPTION
**Description**
Users targeting boards with non-default pin assignments (e.g. ESP32 with alternate SDA/SCL or SPI GPIOs) previously had to modify library source to call `Wire.begin(sda, scl)` or `SPI.begin(sck, miso, mosi, cs)` with custom pins.

This adds four new constructor overloads that accept optional pin parameters:

```cpp
// I2C with custom SDA/SCL
ICM456xx imu(Wire, false, SDA_PIN, SCL_PIN);

// I2C with custom frequency and SDA / SCL
ICM456xx imu(Wire, false, 400000, SDA_PIN, SCL_PIN);

// SPI with custom SCK / MISO / MOSI
ICM456xx imu(SPI, SS, SCK_PIN, MISO_PIN, MOSI_PIN);

// SPI with custom frequency and SCK/MISO/MOSI
ICM456xx imu(SPI, SS, 1000000, SCK_PIN, MISO_PIN, MOSI_PIN);
```

Pin values are stored as protected `int` members (default `-1`). In `begin()`, the pin-aware `bus.begin()` overload is called only when all required pins are explicitly set, preserving existing behaviour for all current users.

**Verification**
- Build and run existing `Polling_I2C` and `Polling_SPI` examples - no constructor changes required, behaviour unchanged.
- On an ESP32 with non-default I2C pins, instantiate with `-DSDA_PIN=21 -DSCL_PIN=22` and confirm `Wire.begin(sda, scl)` is called correctly.
- On an ESP32 with non-default SPI pins, instantiate with custom SCK/MISO/MOSI and confirm `SPI.begin(sck, miso, mosi, cs)` is called correctly.
- Confirm that passing only some pin values (e.g. valid SDA but `-1` SCL) falls back to the default `bus.begin()` call.